### PR TITLE
Install maildrop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV HOSTNAME mail.hashbang.sh
 ENV LDAP_HOST ldap.hashbang.sh
 
 RUN apt-get update && \
-    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y postfix postfix-ldap rsyslog && \
+    LC_ALL=C DEBIAN_FRONTEND=noninteractive apt-get install -y postfix postfix-ldap rsyslog maildrop && \
     apt-get clean && \
     rm -rf /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Maildrop is a more featureful MDA.  Having it installed, without further configuration, enables user to opt into using it by putting `|/usr/bin/maildrop -d ${USER}` in `~/.forward`.

In turn, this lets them write custom filters in `~/.mailfilter`, such as:

```
exception {
  xfilter "mimegpg -e -- -r $USER"  # Encrypt incoming email that is not already encrypted.
}
```
