### PR TITLE
Configuration changes

### DIFF
--- a/docker-postfix.service
+++ b/docker-postfix.service
@@ -13,6 +13,7 @@ ExecStart=/usr/bin/docker run \
   -v /home/core/postfix/certs:/etc/postfix/certs \
   -e HOSTNAME=mail.hashbang.sh \
   -e LDAP_HOST=ldap.hashbang.sh \
+  -e MUST_SSL=yes \
   --name="postfix" \
   hashbang/postfix
 

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,6 @@
 postconf -e myhostname=$HOSTNAME
 postconf -e transport_maps="ldap:/etc/postfix/ldap-transport.cf"
 postconf -e relay_domains="hashbang.sh"
-postconf -e virtual_alias_maps="ldap:/etc/postfix/ldap-aliases.cf"
 postconf -e mydestination="localhost, mail.hashbang.sh"
 
 if [[ -n $LDAP_HOST ]]; then
@@ -14,14 +13,6 @@ query_filter = mailRoutingAddress=%s
 result_attribute = host
 result_format = smtp:[%s]
 EOF
-
-    cat >> /etc/postfix/ldap-aliases.cf <<EOF
-server_host = ldap.hashbang.sh
-search_base = ou=People,dc=hashbang,dc=sh
-query_filter = (&(objectclass=inetLocalMailRecipient)(mailLocalAddress=%s))
-result_attribute = mailRoutingAddress
-EOF
-
 fi
 
 if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && \

--- a/run.sh
+++ b/run.sh
@@ -32,6 +32,9 @@ if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && \
     postconf -e smtpd_tls_session_cache_timeout=3600s
     postconf -e smtp_tls_note_starttls_offer=yes
     postconf -e smtp_tls_security_level=may
+elif [[ -n $MUST_SSL ]]; then
+    echo "SSL is required, but files missing" >2
+    exit 1
 fi
 
 ln /etc/services /var/spool/postfix/etc/services

--- a/run.sh
+++ b/run.sh
@@ -44,6 +44,8 @@ fi
 
 ln /etc/services /var/spool/postfix/etc/services
 cp /etc/resolv.conf /var/spool/postfix/etc/resolv.conf
+
+service rsyslog start
 /usr/sbin/postfix -v -c /etc/postfix start
-touch /var/log/mail.log
+
 tail -f /var/log/mail.*

--- a/run.sh
+++ b/run.sh
@@ -3,6 +3,7 @@
 postconf -e myhostname=$HOSTNAME
 postconf -e transport_maps="ldap:/etc/postfix/ldap-transport.cf"
 postconf -e relay_domains="hashbang.sh"
+postconf -e mynetworks="hashbang.sh"
 
 if [[ -n $LDAP_HOST ]]; then
     cat >> /etc/postfix/ldap-transport.cf <<EOF

--- a/run.sh
+++ b/run.sh
@@ -31,8 +31,12 @@ if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && \
     postconf -e smtpd_tls_loglevel=1
     postconf -e smtpd_tls_received_header=yes
     postconf -e smtpd_tls_session_cache_timeout=3600s
+
+    # Enforce TLS if DANE record found
+    postconf -e smtp_tls_security_level=dane
+    postconf -e smtp_dns_support_level=dnssec
+
     postconf -e smtp_tls_note_starttls_offer=yes
-    postconf -e smtp_tls_security_level=may
 elif [[ -n $MUST_SSL ]]; then
     echo "SSL is required, but files missing" >2
     exit 1

--- a/run.sh
+++ b/run.sh
@@ -3,11 +3,10 @@
 postconf -e myhostname=$HOSTNAME
 postconf -e transport_maps="ldap:/etc/postfix/ldap-transport.cf"
 postconf -e relay_domains="hashbang.sh"
-postconf -e mydestination="localhost, mail.hashbang.sh"
 
 if [[ -n $LDAP_HOST ]]; then
     cat >> /etc/postfix/ldap-transport.cf <<EOF
-server_host = ldap.hashbang.sh
+server_host = $LDAP_HOST
 search_base = ou=People,dc=hashbang,dc=sh
 query_filter = mailRoutingAddress=%s
 result_attribute = host


### PR DESCRIPTION
- Enforce availability of TLS in the production deployment  
  This should avoid a repeat of https://github.com/hashbang/docker-postfix/commit/e874121d1e9f747616ebbf50a51e52b923616694
- Allow relaying mail from our servers
- Honor the `${LDAP_HOST}` environment variable
- Honor DANE records when available
- Drop `ldap-aliases.cf`, it does not work
