### PR TITLE
Rewrite recipient mail addresses

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-postconf -e myhostname=$HOSTNAME
+postconf -e myhostname="$HOSTNAME"
 postconf -e transport_maps="ldap:/etc/postfix/ldap-transport.cf"
 postconf -e relay_domains="hashbang.sh"
 postconf -e mynetworks="127.0.0.0/8 104.245.35.240 104.245.37.138 45.58.35.111 45.58.38.222"
@@ -27,17 +27,17 @@ EOF
 
 fi
 
-if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && \
-      -n "$(find /etc/postfix/certs -iname *.key)" && \
-      -n "$(find /etc/postfix/certs -iname *.pem)"
+if [[ -n "$(find /etc/postfix/certs -iname '*.crt')" && \
+      -n "$(find /etc/postfix/certs -iname '*.key')" && \
+      -n "$(find /etc/postfix/certs -iname '*.pem')"
    ]]; then
 
     echo "Certificates found, enabling TLS."
     chmod 400 /etc/postfix/certs/*.*
 
-    postconf -e smtpd_tls_cert_file=$(find /etc/postfix/certs -iname *.crt)
-    postconf -e smtpd_tls_key_file=$(find /etc/postfix/certs -iname *.key)
-    postconf -e smtpd_tls_CAfile=$(find /etc/postfix/certs -iname *.pem)
+    postconf -e smtpd_tls_cert_file="$(find /etc/postfix/certs -iname '*.crt')"
+    postconf -e smtpd_tls_key_file="$(find /etc/postfix/certs -iname '*.key')"
+    postconf -e smtpd_tls_CAfile="$(find /etc/postfix/certs -iname '*.pem')"
     postconf -e smtpd_tls_security_level=may
     postconf -e smtpd_tls_auth_only=no
     postconf -e smtpd_tls_loglevel=1

--- a/run.sh
+++ b/run.sh
@@ -58,6 +58,6 @@ ln /etc/services    /var/spool/postfix/etc/services
 cp /etc/resolv.conf /var/spool/postfix/etc/resolv.conf
 
 service rsyslog start
-/usr/sbin/postfix -v -c /etc/postfix start
+service postfix start
 
 tail -f /var/log/mail.log

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh -e
 
 postconf -e myhostname="$HOSTNAME"
 postconf -e transport_maps="ldap:/etc/postfix/ldap-transport.cf"
@@ -6,7 +6,7 @@ postconf -e relay_domains="hashbang.sh"
 postconf -e mynetworks="127.0.0.0/8 104.245.35.240 104.245.37.138 45.58.35.111 45.58.38.222"
 postconf -e virtual_alias_maps="ldap:/etc/postfix/ldap-aliases.cf"
 
-if [[ -n $LDAP_HOST ]]; then
+if [ -n "$LDAP_HOST" ]; then
     cat >> /etc/postfix/ldap-transport.cf <<EOF
 server_host = $LDAP_HOST
 search_base = ou=People,dc=hashbang,dc=sh
@@ -27,13 +27,13 @@ EOF
 
 fi
 
-if [[ -n "$(find /etc/postfix/certs -iname '*.crt')" && \
-      -n "$(find /etc/postfix/certs -iname '*.key')" && \
-      -n "$(find /etc/postfix/certs -iname '*.pem')"
-   ]]; then
+if [ -n "$(find /etc/postfix/certs -iname '*.crt')" -a \
+     -n "$(find /etc/postfix/certs -iname '*.key')" -a \
+     -n "$(find /etc/postfix/certs -iname '*.pem')"    \
+   ]; then
 
     echo "Certificates found, enabling TLS."
-    chmod 400 /etc/postfix/certs/*.*
+    chmod 400 /etc/postfix/certs/*
 
     postconf -e smtpd_tls_cert_file="$(find /etc/postfix/certs -iname '*.crt')"
     postconf -e smtpd_tls_key_file="$(find /etc/postfix/certs -iname '*.key')"
@@ -49,12 +49,12 @@ if [[ -n "$(find /etc/postfix/certs -iname '*.crt')" && \
     postconf -e smtp_dns_support_level=dnssec
 
     postconf -e smtp_tls_note_starttls_offer=yes
-elif [[ -n $MUST_SSL ]]; then
+elif [ -n "$MUST_SSL" ]; then
     echo "SSL is required, but files missing" >2
     exit 1
 fi
 
-ln /etc/services /var/spool/postfix/etc/services
+ln /etc/services    /var/spool/postfix/etc/services
 cp /etc/resolv.conf /var/spool/postfix/etc/resolv.conf
 
 service rsyslog start


### PR DESCRIPTION
This patch makes the mailserver rewrite recipient mail addresses to `user@host.hashbang.sh`.
This lets the MDA on the shell servers deliver to the correct user.

Also shipped in this patset is a serie of imrpovements to the `run.sh` script, making it use standard Debian tooling, `sh` rather than `bash`, and proper quoting.
